### PR TITLE
Cr 1459 rate limit eq launch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9-SNAPSHOT</version>
     </dependency>
     <!-- ONS END -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-rate-limiter-client</artifactId>
-      <version>0.0.9-SNAPSHOT</version>
+      <version>0.0.9</version>
     </dependency>
     <!-- ONS END -->
 

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/client/TestClient.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/client/TestClient.java
@@ -5,12 +5,12 @@ import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
-import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
+import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient.Domain;
 
 public interface TestClient {
 
   void checkFulfilmentRateLimit(
-      RateLimiterClient.Domain domain,
+      Domain domain,
       Product product,
       CaseType caseType,
       String ipAddress,
@@ -18,7 +18,10 @@ public interface TestClient {
       String telNo)
       throws CTPException, ResponseStatusException;
 
-  void checkWebformRateLimit(RateLimiterClient.Domain domain, String ipAddress)
+  void checkWebformRateLimit(Domain domain, String ipAddress)
+      throws CTPException, ResponseStatusException;
+
+  void checkEqLaunchLimit(Domain domain, String ipAddress, int loadSheddingModulus)
       throws CTPException, ResponseStatusException;
 
   void rollOverTheHour();

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/BlackListConfig.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/BlackListConfig.java
@@ -1,0 +1,11 @@
+package uk.gov.ons.ctp.integration.envoycuc.config;
+
+import java.util.Set;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("blacklist")
+public class BlackListConfig {
+  private Set<String> ipAddresses;
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/BlackListConfig.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/BlackListConfig.java
@@ -8,4 +8,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("blacklist")
 public class BlackListConfig {
   private Set<String> ipAddresses;
+  private Set<String> telephoneNumbers;
+  private Set<String> uprns;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/RateLimiterClientConfig.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/config/RateLimiterClientConfig.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JCircuitBreakerFactory;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +21,7 @@ import uk.gov.ons.ctp.integration.envoycuc.mockclient.MockLimiter;
 
 @Data
 @NoArgsConstructor
+@EnableConfigurationProperties
 @Configuration
 public class RateLimiterClientConfig {
 
@@ -33,6 +36,13 @@ public class RateLimiterClientConfig {
 
   @Value("${mock-client}")
   private Boolean isMockClient;
+
+  private BlackListConfig blacklistConfig;
+
+  @Autowired
+  public RateLimiterClientConfig(BlackListConfig blacklistConfig) {
+    this.blacklistConfig = blacklistConfig;
+  }
 
   @Bean
   public RateLimitClient rateLimiterClient() {
@@ -52,7 +62,7 @@ public class RateLimiterClientConfig {
   public TestClient testClient() {
     TestClient client;
     if (isMockClient) {
-      client = new MockClient(new MockLimiter());
+      client = new MockClient(new MockLimiter(blacklistConfig));
     } else {
       client = rateLimiterClient();
     }

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import javax.annotation.PostConstruct;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor
@@ -23,19 +24,21 @@ public class StepsContext {
    * hour and goes towards a count To avoid this, I assign a unique value as a prefix to the UPRN,
    * TelNO or IP Address. On @PostConstruct, the unique value is given as Date mmss and is a prefix
    * Each time String getUniqueValueAsString() is called - this value is incremented to give a truly
-   * unique value in tests where we don't care about that particular value
+   * unique value in tests where we don't care about that particular value.
+   *
+   * <p>Note that the prefix must be limited to 3 digits if used for a valid IPv4 address octet.
    *
    * <p>dayHour is used where we want values within a test to be constant for THAT CONTEXT -
    * throughout the whole test This is so that we gain a fixed value for the test, but on rerun a
    * new value is created based on DDDHH and will be unique to the live rate limiter and so that
-   * tests will run as intended and will not be queered by a constantly running rate limiter.
+   * tests will run as intended and will not be queried by a constantly running rate limiter.
    */
   @PostConstruct
   private void createUniqueValue() {
     final Date now = new Date(System.currentTimeMillis());
     SimpleDateFormat formatter = new SimpleDateFormat("mmss");
     uniqueValue = now.getTime();
-    testValuePrefix = formatter.format(now);
+    testValuePrefix = StringUtils.chop(formatter.format(now));
 
     SimpleDateFormat dddMMFormatter = new SimpleDateFormat("DDDHH");
     dayHour = Integer.parseInt(dddMMFormatter.format(now));

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
@@ -1,11 +1,11 @@
 package uk.gov.ons.ctp.integration.envoycuc.context;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import javax.annotation.PostConstruct;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor
@@ -26,7 +26,8 @@ public class StepsContext {
    * Each time String getUniqueValueAsString() is called - this value is incremented to give a truly
    * unique value in tests where we don't care about that particular value.
    *
-   * <p>Note that the prefix must be limited to 3 digits if used for a valid IPv4 address octet.
+   * <p>Note that the prefix must be limited to 3 digits and <= 255, if used for a valid IPv4
+   * address octet.
    *
    * <p>dayHour is used where we want values within a test to be constant for THAT CONTEXT -
    * throughout the whole test This is so that we gain a fixed value for the test, but on rerun a
@@ -36,11 +37,21 @@ public class StepsContext {
   @PostConstruct
   private void createUniqueValue() {
     final Date now = new Date(System.currentTimeMillis());
-    SimpleDateFormat formatter = new SimpleDateFormat("mmss");
     uniqueValue = now.getTime();
-    testValuePrefix = StringUtils.chop(formatter.format(now));
+    testValuePrefix = generateValidOctetDigits();
     SimpleDateFormat dddMMFormatter = new SimpleDateFormat("DDDHH");
     dayHour = Integer.parseInt(dddMMFormatter.format(now));
+  }
+
+  /**
+   * Generate "somewhat" random (within an hour) 3 digits suitable for an IPv4 octet. We divide
+   * seconds by 20 to ensure that we have unique values that span an hour.
+   *
+   * @return "somewhat" random (within an hour) octet of 3 digits
+   */
+  private String generateValidOctetDigits() {
+    int secondsOfDay = LocalDateTime.now().toLocalTime().toSecondOfDay();
+    return "" + ((secondsOfDay / 20) % 256);
   }
 
   public String getUniqueValueAsString() {

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
@@ -39,7 +39,6 @@ public class StepsContext {
     SimpleDateFormat formatter = new SimpleDateFormat("mmss");
     uniqueValue = now.getTime();
     testValuePrefix = StringUtils.chop(formatter.format(now));
-
     SimpleDateFormat dddMMFormatter = new SimpleDateFormat("DDDHH");
     dayHour = Integer.parseInt(dddMMFormatter.format(now));
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/context/StepsContext.java
@@ -58,4 +58,14 @@ public class StepsContext {
     uniqueValue++;
     return uniqueValue.toString();
   }
+
+  public String getUniqueValueAsOctets() {
+    long temp = uniqueValue++;
+    int[] octet = new int[4];
+    for (int i = 0; i < octet.length; i++) {
+      octet[i] = (int) (temp % 256);
+      temp = temp / 256;
+    }
+    return octet[3] + "." + octet[2] + "." + octet[1] + "." + octet[0];
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/main/SpringIntegrationTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/main/SpringIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
+import uk.gov.ons.ctp.integration.envoycuc.config.BlackListConfig;
 import uk.gov.ons.ctp.integration.envoycuc.config.RateLimiterClientConfig;
 import uk.gov.ons.ctp.integration.envoycuc.context.RateLimiterClientRequestContext;
 import uk.gov.ons.ctp.integration.envoycuc.context.StepsContext;
@@ -16,7 +17,8 @@ import uk.gov.ons.ctp.integration.envoycuc.context.StepsContext;
       SpringIntegrationTest.class,
       RateLimiterClientRequestContext.class,
       RateLimiterClientConfig.class,
-      StepsContext.class
+      StepsContext.class,
+      BlackListConfig.class
     },
     loader = SpringBootContextLoader.class,
     initializers = ConfigFileApplicationContextInitializer.class)

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockClient.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockClient.java
@@ -63,7 +63,7 @@ public class MockClient implements TestClient {
       return;
     }
 
-    // TODO Auto-generated method stub
+    // TODO WRITEME code needs to be added when tests added for this check method.
   }
 
   private void checkValidity(final RequestValidationStatus requestValidationStatus) {

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockClient.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockClient.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.integration.envoycuc.mockclient;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.springframework.web.server.ResponseStatusException;
@@ -12,6 +14,7 @@ import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
 import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient.Domain;
 
 public class MockClient implements TestClient {
+  private static final Logger log = LoggerFactory.getLogger(MockClient.class);
 
   private final MockLimiter mockLimiter;
 
@@ -77,8 +80,18 @@ public class MockClient implements TestClient {
   // use the similar code to the real rate limiter client so that we can ensure the test data
   // will pass validation.
   private boolean isValidIpAddress(String ipAddress) {
-    return !StringUtils.isBlank(ipAddress)
-        && InetAddressValidator.getInstance().isValidInet4Address(ipAddress);
+    boolean valid = true;
+    if (StringUtils.isBlank(ipAddress)) {
+      log.with("ipAddress", ipAddress)
+          .warn("Cannot accept blank IP address. This will not be used for rate limit check");
+      valid = false;
+    }
+    if (!InetAddressValidator.getInstance().isValidInet4Address(ipAddress)) {
+      log.with("ipAddress", ipAddress)
+          .warn("IP address is not valid IPv4 format. This will not be used for rate limit check");
+      valid = false;
+    }
+    return valid;
   }
 
   @Override

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockLimiter.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockLimiter.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
@@ -28,13 +29,17 @@ public class MockLimiter {
 
   private final Map<String, Integer> allowanceMap = new HashMap<>();
   private final Map<String, Map<String, List<Integer>>> postingsTimeMap = new HashMap<>();
-  private final List<UniquePropertyReferenceNumber> blackListedUprnList =
-      Collections.singletonList(UniquePropertyReferenceNumber.create("9999999999999"));
+  private final Set<UniquePropertyReferenceNumber> blackListedUprns;
   private final Set<String> blackListedIpAddresses;
-  private final List<String> blackListedTelNoList = Collections.singletonList("blacklisted-telNo");
+  private final Set<String> blackListedTelNumbers;
 
   public MockLimiter(BlackListConfig blackListConfig) {
     blackListedIpAddresses = blackListConfig.getIpAddresses();
+    blackListedTelNumbers = blackListConfig.getTelephoneNumbers();
+    blackListedUprns =
+        blackListConfig.getUprns().stream()
+            .map(s -> UniquePropertyReferenceNumber.create(s))
+            .collect(Collectors.toSet());
     setupAllowances();
   }
 
@@ -122,8 +127,8 @@ public class MockLimiter {
       boolean isBlackListed = false;
 
       if (blackListedIpAddresses.contains(ipAddress)
-          || blackListedUprnList.contains(uprn)
-          || blackListedTelNoList.contains(telNo)) {
+          || blackListedUprns.contains(uprn)
+          || blackListedTelNumbers.contains(telNo)) {
         numberRequestsAllowed = 0;
         isBlackListed = true;
         requestValidationStatus.setValid(false);

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/steps/LimitTestSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/steps/LimitTestSteps.java
@@ -77,7 +77,7 @@ public class LimitTestSteps {
               individualStr,
               fullUprnStr,
               getUniqueValue(),
-              getUniqueValue());
+              stepsContext.getUniqueValueAsOctets());
       rateLimiterClientRequestContext.addFulfilmentRequest(rateLimiterClientRequest);
     }
   }
@@ -103,7 +103,7 @@ public class LimitTestSteps {
               individualStr,
               getUniqueValue(),
               fullTelephone,
-              getUniqueValue());
+              stepsContext.getUniqueValueAsOctets());
       rateLimiterClientRequestContext.addFulfilmentRequest(rateLimiterClientRequest);
     }
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/steps/LimitTestSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/steps/LimitTestSteps.java
@@ -15,6 +15,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -65,8 +66,7 @@ public class LimitTestSteps {
       final String individualStr,
       final String uprnStr) {
 
-    final String fullUprnStr =
-        uprnStr.equals("9999999999999") ? uprnStr : stepsContext.getTestValuePrefix() + uprnStr;
+    final String fullUprnStr = enrichUprn(uprnStr);
 
     for (int i = 0; i < numberRequest; i++) {
       final RateLimiterClientFulfilmentRequest rateLimiterClientRequest =
@@ -92,10 +92,7 @@ public class LimitTestSteps {
       final String individualStr,
       final String telephone) {
 
-    final String fullTelephone =
-        telephone.equals("blacklisted-telNo")
-            ? telephone
-            : stepsContext.getTestValuePrefix() + telephone;
+    final String fullTelephone = enrichTelephoneNumber(telephone);
 
     for (int i = 0; i < numberRequests; i++) {
       final RateLimiterClientFulfilmentRequest rateLimiterClientRequest =
@@ -323,10 +320,21 @@ public class LimitTestSteps {
     return stepsContext.getUniqueValueAsString();
   }
 
+  // add prefix to value to remove conflicts, or keep the same for blacklisted values
+  private String enrich(String value, Set<String> blacklistedValues) {
+    return blacklistedValues.contains(value) ? value : stepsContext.getTestValuePrefix() + value;
+  }
+
+  private String enrichTelephoneNumber(String telephone) {
+    return enrich(telephone, blackListConfig.getTelephoneNumbers());
+  }
+
   private String enrichIpAddress(String ipAddress) {
-    return blackListConfig.getIpAddresses().contains(ipAddress)
-        ? ipAddress
-        : stepsContext.getTestValuePrefix() + ipAddress;
+    return enrich(ipAddress, blackListConfig.getIpAddresses());
+  }
+
+  private String enrichUprn(String uprnStr) {
+    return enrich(uprnStr, blackListConfig.getUprns());
   }
 
   @Given("I have {int} webform requests for ipAddress {string}")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,6 +23,10 @@ envoy:
   scheme: http
 
 blacklist:
-   ip-addresses:
-       - 8.8.8.8
-       - 8.8.4.4
+  ip-addresses:
+      - 8.8.8.8
+      - 8.8.4.4
+  telephone-numbers:
+      - blacklisted-telNo
+  uprns:
+      - 9999999999999

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,3 +21,8 @@ envoy:
   host: localhost
   port: 8181
   scheme: http
+
+blacklist:
+   ip-addresses:
+       - 8.8.8.8
+       - 8.8.4.4

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,6 +14,7 @@ logging:
     uk.gov.ons.ctp: INFO
     # reduce logging from the ratelimiter, otherwise it makes concourse output cumbersome.
     uk.gov.ons.ctp.integration.ratelimiter: WARN
+    uk.gov.ons.ctp.common.rest.RestClient: WARN
     org.springframework: ERROR
   profile: DEV
   useJson: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,8 @@ logging:
   level:
     root: INFO
     uk.gov.ons.ctp: INFO
+    # reduce logging from the ratelimiter, otherwise it makes concourse output cumbersome.
+    uk.gov.ons.ctp.integration.ratelimiter: WARN
     org.springframework: ERROR
   profile: DEV
   useJson: false

--- a/src/test/resources/features/limiter-test.feature
+++ b/src/test/resources/features/limiter-test.feature
@@ -57,7 +57,7 @@ Feature: This feature tests all of the requirements for the Envoy Proxy Limiter 
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "HH"        | "true"     | ".1.1.4"               |
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "SPG"       | "true"     | ".1.1.5"               |
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "CE"        | "true"     | ".1.1.6"               |
-      | 150           |   0            | 150            | "UAC"         | "SMS"           | "CE"        | "true"     | "blacklisted-ipAddress"|
+      | 150           |   0            | 150            | "UAC"         | "SMS"           | "CE"        | "true"     | "8.8.8.8"              |
 
   @LimiterWebformTestIPAddress
   Scenario Outline: IP ADDRESS TEST FOR WEBFORM

--- a/src/test/resources/features/roll-forward.feature
+++ b/src/test/resources/features/roll-forward.feature
@@ -63,8 +63,9 @@ Feature: This feature tests that tests can be rerun once the hour ticks over and
       | 150           |   0            | 150            | "UAC"         | "SMS"           | "CE"        | "true"     | "8.8.8.8"              |
 
   @RollForwardWebformTestIPAddress
-  Scenario Outline: IP ADDRESS TEST FOR WEBFORM
+  Scenario Outline: Roll Forward - IP ADDRESS TEST FOR WEBFORM
     Given I have <numWebformRequests> webform requests for ipAddress <ipAddress>
+    And I wait until the hour
     When I post the webform requests to the envoy proxy client
     Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
     Examples:

--- a/src/test/resources/features/roll-forward.feature
+++ b/src/test/resources/features/roll-forward.feature
@@ -60,7 +60,7 @@ Feature: This feature tests that tests can be rerun once the hour ticks over and
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "HH"        | "true"     | ".1.1.4"               |
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "SPG"       | "true"     | ".1.1.5"               |
       | 150           |   100          | 50             | "UAC"         | "SMS"           | "CE"        | "true"     | ".1.1.6"               |
-      | 150           |   0            | 150            | "UAC"         | "SMS"           | "CE"        | "true"     | "blacklisted-ipAddress"|
+      | 150           |   0            | 150            | "UAC"         | "SMS"           | "CE"        | "true"     | "8.8.8.8"              |
 
   @RollForwardWebformTestIPAddress
   Scenario Outline: IP ADDRESS TEST FOR WEBFORM


### PR DESCRIPTION
CR-1459 describes the requirement for Rate limiting our calls to EQ launcher via the RHSvc endpoint survey-launched call.

As part of the change, it requires IPv4 client IP to come through and it was decided that all the rate-limiting methods should have consistent validation for this.

The changes include:
- change IP blacklist to a valid IPv4 (in this case 8.8.8.8 was chosen)
- all the blacklist information is configured into `application.yml`
- the prefix generator , which is used for uniqueness for several elements , one of which the IP, needs to be a valid octet. I have changed this so that it conforms to octet validation while trying to keep the uniqueness property for reruns of the test.
- added a unique IP address generator for those tests that require new IP addresses each time.
- as agreed with @philwhiles  I have reduced the logging noise so that when run in concourse it does not make reading the results cumbersome.

Note: The RH terraform PR https://github.com/ONSdigital/census-rh-terraform/pull/304 alters the envoy configuration to ensure the blacklisted IP fits with the changes.

JIRA is here: https://collaborate2.ons.gov.uk/jira/browse/CR-1459