### PR TITLE
Updated mock rate limiter class with updated limits for LARGE_PRINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project comprises 3 features
 
 3. Cross-Over Tests 
         CONTINUATION-POST.feature
+        LARGE-PRINT-POST-HH.feature
+        LARGE-PRINT-POST-SPG.feature
         QUESTIONNAIRE-POST-HH.feature
         QUESTIONNAIRE-POST-SPG.feature
         UAC-POST-CE.feature
@@ -53,6 +55,8 @@ mvn clean install will cause a maven task to run the glue classes which drive th
    
 Added Webform test that checks for 100 requests per IP address in an hour
 Added Webform endpoint to MockClient and MockLimiter   
+
+Added tests for large print fulfilments
 
      
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ This project comprises 3 features
     Or if running against the MockClient (export mock_client=true) locally, it rolls the MockClient forward an hour, so these tests can be run.
 
 3. Cross-Over Tests 
-        CONTINUATION-POST.feature
-        LARGE-PRINT-POST-HH.feature
-        LARGE-PRINT-POST-SPG.feature
-        QUESTIONNAIRE-POST-HH.feature
-        QUESTIONNAIRE-POST-SPG.feature
-        UAC-POST-CE.feature
-        UAC-POST-HH.feature
-        UAC-POST-SPG.feature
-        UAC-SMS-CE.feature
-        UAC-SMS-HH.feature
-        UAC-SMS-SPG.feature
-
+        
+        - CONTINUATION-POST.feature
+        - LARGE-PRINT-POST-HH.feature
+        - LARGE-PRINT-POST-SPG.feature
+        - QUESTIONNAIRE-POST-HH.feature
+        - QUESTIONNAIRE-POST-SPG.feature
+        - UAC-POST-CE.feature
+        - UAC-POST-HH.feature
+        - UAC-POST-SPG.feature
+        - UAC-SMS-CE.feature
+        - UAC-SMS-HH.feature
+        - UAC-SMS-SPG.feature
+        
     These tests test multiple rates together in a combination of tests. So limits run over into the next scenario with an Outline and feature
     
 Mock Client and Mock Limiter

--- a/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockLimiter.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/envoycuc/mockclient/MockLimiter.java
@@ -251,11 +251,11 @@ public class MockLimiter {
     allowanceMap.put("POST-QUESTIONNAIRE-TRUE-SPG-UPRN", 5);
     allowanceMap.put("POST-QUESTIONNAIRE-TRUE-CE-UPRN", 50);
 
-    allowanceMap.put("POST-LARGE_PRINT-FALSE-HH-UPRN", 1);
-    allowanceMap.put("POST-LARGE_PRINT-FALSE-SPG-UPRN", 1);
+    allowanceMap.put("POST-LARGE_PRINT-FALSE-HH-UPRN", 5);
+    allowanceMap.put("POST-LARGE_PRINT-FALSE-SPG-UPRN", 5);
 
-    allowanceMap.put("POST-LARGE_PRINT-TRUE-HH-UPRN", 5);
-    allowanceMap.put("POST-LARGE_PRINT-TRUE-SPG-UPRN", 5);
+    allowanceMap.put("POST-LARGE_PRINT-TRUE-HH-UPRN", 10);
+    allowanceMap.put("POST-LARGE_PRINT-TRUE-SPG-UPRN", 10);
     allowanceMap.put("POST-LARGE_PRINT-TRUE-CE-UPRN", 50);
 
     allowanceMap.put("POST-CONTINUATION-FALSE-HH-UPRN", 12);

--- a/src/test/resources/features/combotests/LARGE-PRINT-POST-HH.feature
+++ b/src/test/resources/features/combotests/LARGE-PRINT-POST-HH.feature
@@ -1,0 +1,26 @@
+Feature: This feature tests all of the requirements for the Envoy Proxy Limiter - as combinations of requests telephone, ipAddress and uprn
+  I want to test Fulfilment Journeys using the Rate Limiter for all combinations
+
+  @LargePrintPostHHNonIndividual
+  Scenario Outline: Combinations TEST - LARGE_PRINT POST HH Non-Individual
+    Given I have <noFulfilments> fulfilment requests of product group <productGroup> delivery channel <deliveryChannel> case type <caseType> individual is <individual> telephone <telNo> ipAddress <ipAddress> uprn <uprn>
+    When I post the fulfilments to the envoy proxy client
+    Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
+
+    Examples:
+      | noFulfilments | expectedToPass | expectedToFail | productGroup  | deliveryChannel  | caseType | individual | telNo     | ipAddress | uprn     |
+      | 15            | 10             | 5              |"LARGE_PRINT"| "POST"           | "HH"       | "false"    | "0000000" | ".0.7.9"  | "901112" |
+      | 10            | 0              | 10             |"LARGE_PRINT"| "POST"           | "HH"       | "false"    | "0000000" | ".0.8.9"  | "901112" |
+      | 10            | 10             | 0              |"LARGE_PRINT"| "POST"           | "HH"       | "false"    | "0000000" | ".0.9.9"  | "901114" |
+
+  @LargePrintPostHHIndividual
+  Scenario Outline: Combinations TEST - LARGE_PRINT POST HH Individual
+    Given I have <noFulfilments> fulfilment requests of product group <productGroup> delivery channel <deliveryChannel> case type <caseType> individual is <individual> telephone <telNo> ipAddress <ipAddress> uprn <uprn>
+    When I post the fulfilments to the envoy proxy client
+    Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
+
+    Examples:
+      | noFulfilments | expectedToPass | expectedToFail | productGroup  | deliveryChannel | caseType | individual | telNo     | ipAddress | uprn     |
+      | 15            | 10             | 5              |"LARGE_PRINT"| "POST"          | "HH"       | "true"     | "0000000" | ".0.0.7"  | "901112" |
+      | 10            | 0              | 10             |"LARGE_PRINT"| "POST"          | "HH"       | "true"     | "0000000" | ".0.1.7"  | "901112" |
+      | 10            | 10             | 0              |"LARGE_PRINT"| "POST"          | "HH"       | "true"     | "0000000" | ".0.2.7"  | "901114" |

--- a/src/test/resources/features/combotests/LARGE-PRINT-POST-SPG.feature
+++ b/src/test/resources/features/combotests/LARGE-PRINT-POST-SPG.feature
@@ -1,0 +1,38 @@
+Feature: This feature tests all of the requirements for the Envoy Proxy Limiter - as combinations of requests telephone, ipAddress and uprn
+  I want to test Fulfilment Journeys using the Rate Limiter for all combinations
+
+  @LargePrintPostSPGNonIndividual
+  Scenario Outline: Combinations TEST - LARGE_PRINT POST SPG Non-Individual
+    Given I have <noFulfilments> fulfilment requests of product group <productGroup> delivery channel <deliveryChannel> case type <caseType> individual is <individual> telephone <telNo> ipAddress <ipAddress> uprn <uprn>
+    When I post the fulfilments to the envoy proxy client
+    Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
+
+    Examples:
+      | noFulfilments | expectedToPass | expectedToFail | productGroup  | deliveryChannel  | caseType    | individual | telNo     | ipAddress | uprn     |
+      | 15            | 10             | 5              |"LARGE_PRINT"| "POST"           | "SPG"       | "false"    | "0000000" | ".0.7.9"  | "921112" |
+      | 10            | 0              | 10             |"LARGE_PRINT"| "POST"           | "SPG"       | "false"    | "0000000" | ".0.8.9"  | "921112" |
+      | 10            | 10             | 0              |"LARGE_PRINT"| "POST"           | "SPG"       | "false"    | "0000000" | ".0.9.9"  | "921114" |
+
+  @LargePrintPostSPGIndividual
+  Scenario Outline: Combinations TEST - LARGE_PRINT POST SPG Individual
+    Given I have <noFulfilments> fulfilment requests of product group <productGroup> delivery channel <deliveryChannel> case type <caseType> individual is <individual> telephone <telNo> ipAddress <ipAddress> uprn <uprn>
+    When I post the fulfilments to the envoy proxy client
+    Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
+
+    Examples:
+      | noFulfilments | expectedToPass | expectedToFail | productGroup  | deliveryChannel | caseType    | individual | telNo     | ipAddress | uprn     |
+      | 15            | 10             | 5              |"LARGE_PRINT"| "POST"          | "SPG"       | "true"     | "0000000" | ".0.0.7"  | "921112" |
+      | 10            | 0              | 10             |"LARGE_PRINT"| "POST"          | "SPG"       | "true"     | "0000000" | ".0.1.7"  | "921112" |
+      | 10            | 10             | 0              |"LARGE_PRINT"| "POST"          | "SPG"       | "true"     | "0000000" | ".0.2.7"  | "921114" |
+
+  @LargePrintPostCEIndividual
+  Scenario Outline: Combinations TEST - LARGE_PRINT POST CE Individual
+    Given I have <noFulfilments> fulfilment requests of product group <productGroup> delivery channel <deliveryChannel> case type <caseType> individual is <individual> telephone <telNo> ipAddress <ipAddress> uprn <uprn>
+    When I post the fulfilments to the envoy proxy client
+    Then I expect the first <expectedToPass> calls to succeed and <expectedToFail> calls to fail
+
+    Examples:
+      | noFulfilments | expectedToPass | expectedToFail | productGroup  | deliveryChannel | caseType   | individual | telNo     | ipAddress | uprn     |
+      | 40            | 40             | 0              |"LARGE_PRINT"| "POST"          | "CE"       | "true"     | "0000000" | ".0.9.0"  | "921112" |
+      | 20            | 10             | 10             |"LARGE_PRINT"| "POST"          | "CE"       | "true"     | "0000000" | ".0.2.1"  | "921112" |
+      | 60            | 50             | 10             |"LARGE_PRINT"| "POST"          | "CE"       | "true"     | "0000000" | ".0.2.2"  | "921114" |


### PR DESCRIPTION
Updated mock rate limiter class with updated limits for LARGE_PRINT fulfilments

LARGE_PRINT (INDIVIDUAL)=FALSE POST 5 HH uprn
LARGE_PRINT (INDIVIDUAL)=FALSE POST 5 SPG uprn
LARGE_PRINT (INDIVIDUAL)=TRUE POST 10 HH uprn
LARGE_PRINT (INDIVIDUAL)=TRUE POST 10 SPG uprn